### PR TITLE
fix CI portable SDK dependencies

### DIFF
--- a/.agents/notes/implemented/release/2026-08-18-dsh-plugin-0.2.5.md
+++ b/.agents/notes/implemented/release/2026-08-18-dsh-plugin-0.2.5.md
@@ -2,7 +2,7 @@
 
 ## Scope
 
-- Release Web UI group creation with a name and 1–50 initial Handle or DID members through the Rust IM Core `0.1.4` facade.
+- Release Web UI group creation with a name and 1–50 initial Handle or DID members through the Rust IM Core `0.1.5` facade.
 - Preserve group titles, Direct display names, and group-sender labels through local Core presentation data and identity-scoped browser projections.
 - Reconcile optimistic sends by exact client message ID, keep background refresh failures quiet while local content remains usable, and retain the local-first conversation timeline.
 - Cache verified image previews in bounded browser-runtime, identity-scoped IndexedDB, and private Host-disk layers so a full page reload does not enter the Remote request queue.

--- a/README.md
+++ b/README.md
@@ -219,7 +219,7 @@ pnpm run verify
 pnpm pack --dry-run
 ```
 
-The production Host loads the exact `@awiki/im-core-node@0.1.4` runtime package;
+The production Host loads the exact `@awiki/im-core-node@0.1.5` runtime package;
 the platform-specific native addon is selected through its optional dependencies
 and remains external to the JavaScript bundle. Consumers do not need Rust or an
 `awiki-cli-rs2` checkout. See `THIRD_PARTY_NOTICES.md` for provenance and

--- a/README.zh.md
+++ b/README.zh.md
@@ -186,7 +186,7 @@ pnpm run verify
 pnpm pack --dry-run
 ```
 
-生产 Host 加载固定版本 `@awiki/im-core-node@0.1.4`；平台原生 addon 由它的
+生产 Host 加载固定版本 `@awiki/im-core-node@0.1.5`；平台原生 addon 由它的
 optional dependencies 选择，并保持在 JavaScript bundle 外。使用者无需安装 Rust，
 也无需检出 `awiki-cli-rs2`。来源与许可证见 `THIRD_PARTY_NOTICES.md`。
 

--- a/THIRD_PARTY_NOTICES.md
+++ b/THIRD_PARTY_NOTICES.md
@@ -2,7 +2,7 @@
 
 ## AWiki Rust IM Core Node SDK
 
-`@awiki/im-core-node@0.1.4` and its target-specific optional package provide the
+`@awiki/im-core-node@0.1.5` and its target-specific optional package provide the
 Rust IM Core runtime used by the Host provider. These packages are distributed
 under AGPL-3.0-only. Each package carries its own `LICENSE`, `NOTICE.md`,
 `SOURCE.md`, CycloneDX SBOM, checksums, and build provenance. The corresponding

--- a/package.json
+++ b/package.json
@@ -119,7 +119,7 @@
     }
   },
   "dependencies": {
-    "@awiki/im-core-node": "0.1.4",
+    "@awiki/im-core-node": "0.1.5",
     "@deepseek-ai/schemastery": "^3.18.1",
     "zod": "^4.4.3"
   },
@@ -144,7 +144,13 @@
     "@deepseek-ai/dsh-settings": "0.1.0-rc.7",
     "@deepseek-ai/dsh-tools": "0.1.0-rc.7",
     "@deepseek-ai/dsh-typert-protocol": "0.1.0-rc.7",
+    "@deepseek-ai/dsh-workspace": "0.1.0-rc.7",
     "react": "^18.2.0"
+  },
+  "peerDependenciesMeta": {
+    "@deepseek-ai/dsh-workspace": {
+      "optional": true
+    }
   },
   "devDependencies": {
     "@deepseek-ai/cordis": "^4.0.1",
@@ -175,6 +181,7 @@
     "@deepseek-ai/dsh-typert-generator": "0.1.0-rc.7",
     "@deepseek-ai/dsh-typert-protocol": "0.1.0-rc.7",
     "@deepseek-ai/dsh-user-approval": "0.1.0-rc.7",
+    "@deepseek-ai/dsh-workspace": "0.1.0-rc.7",
     "@testing-library/react": "^16.3.2",
     "@types/node": "^24.3.0",
     "@types/react": "^18.3.23",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4,16 +4,13 @@ settings:
   autoInstallPeers: true
   excludeLinksFromLockfile: false
 
-overrides:
-  '@awiki/im-core-node': link:../awiki-cli-rs2/packages/awiki-im-core-node
-
 importers:
 
   .:
     dependencies:
       '@awiki/im-core-node':
-        specifier: link:../awiki-cli-rs2/packages/awiki-im-core-node
-        version: link:../awiki-cli-rs2/packages/awiki-im-core-node
+        specifier: 0.1.5
+        version: 0.1.5
       '@deepseek-ai/schemastery':
         specifier: ^3.18.1
         version: 3.18.1
@@ -105,6 +102,9 @@ importers:
       '@deepseek-ai/dsh-user-approval':
         specifier: 0.1.0-rc.7
         version: 0.1.0-rc.7(fa1b48102029c2e7a43d141c0b635be4)
+      '@deepseek-ai/dsh-workspace':
+        specifier: 0.1.0-rc.7
+        version: 0.1.0-rc.7(ec998407dc4462e22f5b87532bf64f22)
       '@testing-library/react':
         specifier: ^16.3.2
         version: 16.3.2(@testing-library/dom@10.4.1)(@types/react-dom@18.3.7(@types/react@18.3.31))(@types/react@18.3.31)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
@@ -158,6 +158,42 @@ packages:
 
   '@asamuzakjp/css-color@2.8.2':
     resolution: {integrity: sha512-RtWv9jFN2/bLExuZgFFZ0I3pWWeezAHGgrmjqGGWclATl1aDe3yhCUaI0Ilkp6OCk9zX7+FjvDasEX8Q9Rxc5w==}
+
+  '@awiki/im-core-node-darwin-arm64@0.1.5':
+    resolution: {integrity: sha512-So4yxkBl4DVa0ZOq8LhbjEnb270eq6pWcRTTt7wNSY7b1AGPHCHnRdK0lpG99qbPDcYC+SdaU2NXVGEkZmKZzg==}
+    engines: {node: ^22.19.0 || >=24.0.0}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@awiki/im-core-node-darwin-x64@0.1.5':
+    resolution: {integrity: sha512-chgDQiZxmRJRdbkbuYlvMBrejcRWquex/9hrOResc2I+DzKQe0xNG24vxrMGahuS/fWmsWJht+j6Gzq8AosBDA==}
+    engines: {node: ^22.19.0 || >=24.0.0}
+    cpu: [x64]
+    os: [darwin]
+
+  '@awiki/im-core-node-linux-arm64-gnu@0.1.5':
+    resolution: {integrity: sha512-roLILPC1rEyes+sR1vgIWN6g1NJ7wi5SzMwArWML0/Q5EcvNZdXNAY9+q5A0qn6erWmCgaPp1/z1mZSG92u+SQ==}
+    engines: {node: ^22.19.0 || >=24.0.0}
+    cpu: [arm64]
+    os: [linux]
+    libc: [glibc]
+
+  '@awiki/im-core-node-linux-x64-gnu@0.1.5':
+    resolution: {integrity: sha512-r3PmRyltJUTaKczwdr10radfHRMcP6e07QIKcqJxsfap93EbDUTtAgXw0utPlUf0JOlFnSoJKhRlxxuq3tLddg==}
+    engines: {node: ^22.19.0 || >=24.0.0}
+    cpu: [x64]
+    os: [linux]
+    libc: [glibc]
+
+  '@awiki/im-core-node-win32-x64-msvc@0.1.5':
+    resolution: {integrity: sha512-arf5OYvOGaq8MskRnEN5Eac+Q8STLNCH41mCpv6CQnBBONk5hBDBGLVKInZh+TF9lYZSn28uMMOLNKm6/XGwBg==}
+    engines: {node: ^22.19.0 || >=24.0.0}
+    cpu: [x64]
+    os: [win32]
+
+  '@awiki/im-core-node@0.1.5':
+    resolution: {integrity: sha512-F1n/XPR08xe2SkVJekl20Tq56tzmY4kPmQPYFyezBhK1pIIf31bosHa/Gdy3teX5MUdPOViXJpjtl0gyWScL6w==}
+    engines: {node: ^22.19.0 || >=24.0.0}
 
   '@aws-crypto/sha256-browser@5.2.0':
     resolution: {integrity: sha512-AXfN/lGotSQwu6HNcEsIASo7kWXZ5HYWvfOmSNKDsEqC4OashTp8alTmaz+F7TC2L083SFv5RdB+qU3Vs1kZqw==}
@@ -4905,6 +4941,29 @@ snapshots:
       '@csstools/css-parser-algorithms': 3.0.4(@csstools/css-tokenizer@3.0.3)
       '@csstools/css-tokenizer': 3.0.3
       lru-cache: 11.5.2
+
+  '@awiki/im-core-node-darwin-arm64@0.1.5':
+    optional: true
+
+  '@awiki/im-core-node-darwin-x64@0.1.5':
+    optional: true
+
+  '@awiki/im-core-node-linux-arm64-gnu@0.1.5':
+    optional: true
+
+  '@awiki/im-core-node-linux-x64-gnu@0.1.5':
+    optional: true
+
+  '@awiki/im-core-node-win32-x64-msvc@0.1.5':
+    optional: true
+
+  '@awiki/im-core-node@0.1.5':
+    optionalDependencies:
+      '@awiki/im-core-node-darwin-arm64': 0.1.5
+      '@awiki/im-core-node-darwin-x64': 0.1.5
+      '@awiki/im-core-node-linux-arm64-gnu': 0.1.5
+      '@awiki/im-core-node-linux-x64-gnu': 0.1.5
+      '@awiki/im-core-node-win32-x64-msvc': 0.1.5
 
   '@aws-crypto/sha256-browser@5.2.0':
     dependencies:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -11,20 +11,15 @@ allowBuilds:
 
 verifyDepsBeforeRun: false
 
-# Local cross-repository integration binding. The published package manifest
-# remains pinned to the coordinated 0.1.4 SDK candidate.
-overrides:
-  '@awiki/im-core-node': link:../awiki-cli-rs2/packages/awiki-im-core-node
-
 # These exact first-party artifacts were built, checksummed, SBOM-audited, and
 # published together. Keep pnpm's release-age policy for every other package.
 minimumReleaseAgeExclude:
-  - '@awiki/im-core-node-darwin-arm64@0.1.4'
-  - '@awiki/im-core-node-darwin-x64@0.1.4'
-  - '@awiki/im-core-node-linux-arm64-gnu@0.1.4'
-  - '@awiki/im-core-node-linux-x64-gnu@0.1.4'
-  - '@awiki/im-core-node-win32-x64-msvc@0.1.4'
-  - '@awiki/im-core-node@0.1.4'
+  - '@awiki/im-core-node-darwin-arm64@0.1.5'
+  - '@awiki/im-core-node-darwin-x64@0.1.5'
+  - '@awiki/im-core-node-linux-arm64-gnu@0.1.5'
+  - '@awiki/im-core-node-linux-x64-gnu@0.1.5'
+  - '@awiki/im-core-node-win32-x64-msvc@0.1.5'
+  - '@awiki/im-core-node@0.1.5'
   - '@deepseek-ai/dsh-agent-default-model@0.1.0-rc.7'
   - '@deepseek-ai/dsh-agent-instructions@0.1.0-rc.7'
   - '@deepseek-ai/dsh-agent-loop@0.1.0-rc.7'

--- a/tests/baseline/migration-contract.json
+++ b/tests/baseline/migration-contract.json
@@ -319,7 +319,7 @@
   "providerContractFixture": "tests/sdk-adapter.spec.ts",
   "rustSdkPackage": {
     "name": "@awiki/im-core-node",
-    "version": "0.1.4"
+    "version": "0.1.5"
   },
   "packedArtifact": {
     "packageVersion": "0.2.5",
@@ -338,7 +338,7 @@
       "lib/sdk-adapter-DCOUHDW_.mjs": 15790
     },
     "runtimeDependencies": {
-      "@awiki/im-core-node": "0.1.4",
+      "@awiki/im-core-node": "0.1.5",
       "@deepseek-ai/schemastery": "^3.18.1",
       "zod": "^4.4.3"
     },
@@ -366,7 +366,7 @@
       "react": "^18.2.0"
     },
     "runtimeSdkDependency": {
-      "@awiki/im-core-node": "0.1.4"
+      "@awiki/im-core-node": "0.1.5"
     },
     "packedSmoke": {
       "imports": [

--- a/tests/package-manifest.spec.ts
+++ b/tests/package-manifest.spec.ts
@@ -4,6 +4,7 @@ import { describe, expect, it } from 'vitest'
 interface PackageManifest {
   readonly dependencies?: Readonly<Record<string, string>>
   readonly peerDependencies?: Readonly<Record<string, string>>
+  readonly peerDependenciesMeta?: Readonly<Record<string, { readonly optional?: boolean }>>
   readonly devDependencies?: Readonly<Record<string, string>>
 }
 
@@ -31,5 +32,13 @@ describe('published package dependency resolution', () => {
 
   it('leaves every Host package to the Harness installation instead of owning a duplicate', () => {
     expect(Object.keys(manifest.dependencies ?? {}).filter(name => harnessPackage.test(name))).toEqual([])
+  })
+
+  it('types the optional listener workspace against the exact Host release', () => {
+    const target = manifest.devDependencies?.['@deepseek-ai/dsh']
+    expect(manifest.peerDependencies?.['@deepseek-ai/dsh-workspace']).toBe(target)
+    expect(manifest.peerDependenciesMeta?.['@deepseek-ai/dsh-workspace']).toEqual({ optional: true })
+    expect(manifest.devDependencies?.['@deepseek-ai/dsh-workspace']).toBe(target)
+    expect(manifest.dependencies?.['@deepseek-ai/dsh-workspace']).toBeUndefined()
   })
 })

--- a/tests/sdk-candidate.spec.ts
+++ b/tests/sdk-candidate.spec.ts
@@ -4,11 +4,20 @@ import { fileURLToPath } from 'node:url'
 import { describe, expect, it } from 'vitest'
 
 describe('AWiki IM Core Node development candidate', () => {
-  it('binds the plugin manifest and loaded facade to the coordinated 0.1.4 API', async () => {
+  it('resolves the published SDK without a repository-external link override', async () => {
+    const workspace = await readFile(new URL('../pnpm-workspace.yaml', import.meta.url), 'utf8')
+    const lockfile = await readFile(new URL('../pnpm-lock.yaml', import.meta.url), 'utf8')
+    const externalLink = /['"]?@awiki\/im-core-node['"]?:\s*link:/u
+
+    expect(workspace).not.toMatch(externalLink)
+    expect(lockfile).not.toMatch(externalLink)
+  })
+
+  it('binds the plugin manifest and loaded facade to the coordinated 0.1.5 API', async () => {
     const manifest = JSON.parse(await readFile(new URL('../package.json', import.meta.url), 'utf8')) as {
       readonly dependencies: Record<string, string>
     }
-    expect(manifest.dependencies['@awiki/im-core-node']).toBe('0.1.4')
+    expect(manifest.dependencies['@awiki/im-core-node']).toBe('0.1.5')
 
     const wrapperEntry = fileURLToPath(import.meta.resolve('@awiki/im-core-node'))
     const wrapperRoot = join(dirname(wrapperEntry), '..')
@@ -16,7 +25,7 @@ describe('AWiki IM Core Node development candidate', () => {
       readonly version: string
     }
     const declaration = await readFile(join(wrapperRoot, 'dist', 'types.d.ts'), 'utf8')
-    expect(installedWrapper.version).toBe('0.1.4')
+    expect(installedWrapper.version).toBe('0.1.5')
     for (const method of ['getMailAccount', 'listMailInbox', 'readMail', 'markMailRead', 'sendMail']) {
       expect(declaration).toContain(`${method}(`)
     }


### PR DESCRIPTION
## What changed

- replace the repository-external `link:` override with published `@awiki/im-core-node@0.1.5`
- add `@deepseek-ai/dsh-workspace@0.1.0-rc.7` as an optional peer and exact development dependency for Host listener typing
- regenerate a minimal registry-backed lockfile with all six Node SDK 0.1.5 packages
- add manifest and lockfile regression coverage so CI cannot silently reintroduce the external SDK link
- align the release contract and documentation with Node SDK 0.1.5

## Root cause

The merged mail plugin compiled locally only because `pnpm-workspace.yaml` redirected the SDK to a sibling checkout. A clean GitHub Actions checkout had neither that sibling repository nor an explicit `dsh-workspace` development dependency, so dependency installation and Host compilation were not portable.

The previously published Node SDK 0.1.4 also exposed native API v4 and did not contain the realtime/mail facade. Node SDK 0.1.5 is now published and provides the coordinated native API v5 surface.

## Impact

Clean CI and user installations now resolve the same published wrapper and platform addon. Consumers still receive Host packages from DeepSeek Harness; the workspace peer remains optional at runtime and is present only for development/type checking.

## Validation

- clean `pnpm install --frozen-lockfile`; supply-chain policy passed
- `pnpm verify`
- public-tree safety scan passed
- build and typecheck passed
- generated Typert contract verified: 24 methods
- Vitest: 30 files, 303 tests passed
- `npm pack --dry-run` passed for `@awiki/dsh-plugin@0.2.5`
- registry acceptance: `@awiki/im-core-node@0.1.5` loaded its native addon and exposed native API v5 mail/realtime methods
