### PR TITLE
release: publish AWiki plugins 0.3.1 and 0.1.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@awiki/dsh-plugin",
-  "version": "0.3.1-rc.1",
+  "version": "0.3.1",
   "description": "AWiki identity and messaging plugin for DeepSeek Harness",
   "type": "module",
   "main": "lib/index.js",

--- a/packages/dsh-model-proxy/package.json
+++ b/packages/dsh-model-proxy/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@awiki/dsh-model-proxy",
-  "version": "0.1.1-rc.1",
+  "version": "0.1.1",
   "description": "AWiki-authenticated model proxy and Quick Recharge UI for DeepSeek Harness",
   "type": "module",
   "main": "lib/index.js",
@@ -76,7 +76,7 @@
     "@deepseek-ai/schemastery": "^3.18.1"
   },
   "peerDependencies": {
-    "@awiki/dsh-plugin": "^0.3.1-rc.1",
+    "@awiki/dsh-plugin": "^0.3.1",
     "@deepseek-ai/cordis": "^4.0.1",
     "@deepseek-ai/dsh-agent-default-model": "0.1.1-rc.2",
     "@deepseek-ai/dsh-anonymous-user-id": "0.1.1-rc.2",

--- a/packages/dsh-model-proxy/tests/package-manifest.spec.ts
+++ b/packages/dsh-model-proxy/tests/package-manifest.spec.ts
@@ -30,7 +30,7 @@ const rootManifest = JSON.parse(readFileSync(
 describe('independent model-proxy package manifest', () => {
   it('owns an independent version plus its Host and Browser contributions', () => {
     expect(manifest.name).toBe('@awiki/dsh-model-proxy')
-    expect(manifest.version).toBe('0.1.1-rc.1')
+    expect(manifest.version).toBe('0.1.1')
     expect(manifest.exports?.['./client']).toEqual({
       types: './lib/types/client/index.d.ts',
       default: './lib/client.js',
@@ -108,7 +108,7 @@ describe('independent model-proxy package manifest', () => {
   })
 
   it('uses the main AWiki package only through a public peer boundary', () => {
-    expect(rootManifest.version).toBe('0.3.1-rc.1')
+    expect(rootManifest.version).toBe('0.3.1')
     expect(manifest.peerDependencies?.['@awiki/dsh-plugin']).toBe(`^${rootManifest.version}`)
     expect(manifest.devDependencies?.['@awiki/dsh-plugin']).toBe('workspace:*')
     expect(manifest.dependencies?.['@awiki/dsh-plugin']).toBeUndefined()


### PR DESCRIPTION
## Summary

- promote @awiki/dsh-plugin from 0.3.1-rc.1 to 0.3.1
- promote @awiki/dsh-model-proxy from 0.1.1-rc.1 to 0.1.1
- require the stable @awiki/dsh-plugin ^0.3.1 peer from Model Proxy
- retain exact DeepSeek Harness 0.1.1-rc.2 compatibility

## Verification

- root verify: 30 test files, 350 tests passed
- Model Proxy verify: 9 test files, 85 tests passed
- public-tree, build, typecheck, generated-boundary, and package tarball checks passed
- both npm packages are already published under the latest tag