### PR TITLE
chore(release): align Shanghai plugin artifacts and native fixtures

### DIFF
--- a/docs/e2e-automation-testing-cli-peer.md
+++ b/docs/e2e-automation-testing-cli-peer.md
@@ -714,3 +714,7 @@ Recovery fixture 同步支持 Schema 3 snapshot capability。最终 public/build
   IM Core source pin 拒绝并保持 `not_run`，secret scan 与 cleanup 均通过。
 - DSH 已合并 canonical nested Identity workspace，并在当前源码上通过 E2E TypeScript 编译及
   Vitest 37 files / 383 tests。最终 Direct/Group/Restart live 回归仍须等待同一干净 CLI candidate。
+
+## 2026-09-07 上海发布夹具更新
+
+本次 IM Core Node 0.2.3 使用 `ba227c1fe616fe4b7d83a069453899c3e344e548`；本地原生夹具和 live runner 的源锁同步到这一发布提交，ANP Identity 仍保持 `8dc65ccc388af0f0622263811776a6aadcd11d18`。历史运行证据保持原样。

--- a/lib/index.js
+++ b/lib/index.js
@@ -3072,7 +3072,7 @@ function legacyDocument(seed, usePreRegistryDefault) {
 //#region lib/types/package-version.generated.js
 /** Generated from package.json by scripts/sync-package-versions.mjs. */
 const DSH_AWIKI_PACKAGE_VERSION = "0.3.9";
-const DSH_AWIKI_MODEL_PROXY_PACKAGE_VERSION = "0.1.4";
+const DSH_AWIKI_MODEL_PROXY_PACKAGE_VERSION = "0.1.5";
 //#endregion
 //#region lib/types/update-policy.js
 /** Tenant-scoped DSH AWiki plugin update policy and verified cache. */

--- a/lib/types/package-version.generated.d.ts
+++ b/lib/types/package-version.generated.d.ts
@@ -1,4 +1,4 @@
 /** Generated from package.json by scripts/sync-package-versions.mjs. */
 export declare const DSH_AWIKI_PACKAGE_VERSION: "0.3.9";
-export declare const DSH_AWIKI_MODEL_PROXY_PACKAGE_VERSION: "0.1.4";
+export declare const DSH_AWIKI_MODEL_PROXY_PACKAGE_VERSION: "0.1.5";
 //# sourceMappingURL=package-version.generated.d.ts.map

--- a/lib/types/package-version.generated.js
+++ b/lib/types/package-version.generated.js
@@ -1,4 +1,4 @@
 /** Generated from package.json by scripts/sync-package-versions.mjs. */
 export const DSH_AWIKI_PACKAGE_VERSION = "0.3.9";
-export const DSH_AWIKI_MODEL_PROXY_PACKAGE_VERSION = "0.1.4";
+export const DSH_AWIKI_MODEL_PROXY_PACKAGE_VERSION = "0.1.5";
 //# sourceMappingURL=package-version.generated.js.map

--- a/lib/types/update-policy.d.ts
+++ b/lib/types/update-policy.d.ts
@@ -1,7 +1,7 @@
 /** Tenant-scoped DSH AWiki plugin update policy and verified cache. */
 import type { AwikiTenantProfile } from './tenant-registry.ts';
 export declare const DSH_AWIKI_VERSION: "0.3.9";
-export declare const DSH_AWIKI_MODEL_PROXY_VERSION: "0.1.4";
+export declare const DSH_AWIKI_MODEL_PROXY_VERSION: "0.1.5";
 export interface AwikiPluginUpdateTarget {
     readonly name: string;
     readonly recommendedVersion: string;

--- a/packages/dsh-model-proxy/lib/index.js
+++ b/packages/dsh-model-proxy/lib/index.js
@@ -13,7 +13,7 @@ function rethrowAwikiPluginDependencyError(error) {
 //#endregion
 //#region lib/types/package-version.generated.js
 /** Generated from package.json by scripts/sync-package-versions.mjs. */
-const DSH_AWIKI_MODEL_PROXY_PACKAGE_VERSION = "0.1.4";
+const DSH_AWIKI_MODEL_PROXY_PACKAGE_VERSION = "0.1.5";
 //#endregion
 //#region lib/types/index.js
 /** Host-only AWiki-authenticated model-proxy provider and loopback account API. */

--- a/packages/dsh-model-proxy/lib/types/package-version.generated.d.ts
+++ b/packages/dsh-model-proxy/lib/types/package-version.generated.d.ts
@@ -1,3 +1,3 @@
 /** Generated from package.json by scripts/sync-package-versions.mjs. */
-export declare const DSH_AWIKI_MODEL_PROXY_PACKAGE_VERSION: "0.1.4";
+export declare const DSH_AWIKI_MODEL_PROXY_PACKAGE_VERSION: "0.1.5";
 //# sourceMappingURL=package-version.generated.d.ts.map

--- a/packages/dsh-model-proxy/lib/types/package-version.generated.js
+++ b/packages/dsh-model-proxy/lib/types/package-version.generated.js
@@ -1,3 +1,3 @@
 /** Generated from package.json by scripts/sync-package-versions.mjs. */
-export const DSH_AWIKI_MODEL_PROXY_PACKAGE_VERSION = "0.1.4";
+export const DSH_AWIKI_MODEL_PROXY_PACKAGE_VERSION = "0.1.5";
 //# sourceMappingURL=package-version.generated.js.map

--- a/packages/dsh-model-proxy/package.json
+++ b/packages/dsh-model-proxy/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@awiki/dsh-model-proxy",
-  "version": "0.1.4",
+  "version": "0.1.5",
   "description": "AWiki-authenticated model proxy and Quick Recharge UI for DeepSeek Harness",
   "type": "module",
   "main": "lib/index.js",

--- a/packages/dsh-model-proxy/src/package-version.generated.ts
+++ b/packages/dsh-model-proxy/src/package-version.generated.ts
@@ -1,2 +1,2 @@
 /** Generated from package.json by scripts/sync-package-versions.mjs. */
-export const DSH_AWIKI_MODEL_PROXY_PACKAGE_VERSION = "0.1.4" as const
+export const DSH_AWIKI_MODEL_PROXY_PACKAGE_VERSION = "0.1.5" as const

--- a/packages/dsh-model-proxy/tests/package-manifest.spec.ts
+++ b/packages/dsh-model-proxy/tests/package-manifest.spec.ts
@@ -32,7 +32,7 @@ const rootManifest = JSON.parse(readFileSync(
 describe('independent model-proxy package manifest', () => {
   it('owns an independent version plus its Host and Browser contributions', () => {
     expect(manifest.name).toBe('@awiki/dsh-model-proxy')
-    expect(manifest.version).toBe('0.1.4')
+    expect(manifest.version).toBe('0.1.5')
     expect(DSH_AWIKI_MODEL_PROXY_PACKAGE_VERSION).toBe(manifest.version)
     expect(DSH_AWIKI_VERSION).toBe(rootManifest.version)
     expect(manifest.exports?.['./client']).toEqual({

--- a/scripts/prepare-e2e-native-fixtures.mjs
+++ b/scripts/prepare-e2e-native-fixtures.mjs
@@ -6,7 +6,7 @@ const repositoryRoot = resolve(dirname(fileURLToPath(import.meta.url)), '..')
 const identityRoot = resolve(repositoryRoot, '../anp/anp-identity')
 const cliRoot = resolve(repositoryRoot, '../awiki-cli-rs2')
 const identitySourceRef = '8dc65ccc388af0f0622263811776a6aadcd11d18'
-const imCoreSourceRef = 'c2a9a2b6ee80e0668592731b678701d16f6399f6'
+const imCoreSourceRef = 'ba227c1fe616fe4b7d83a069453899c3e344e548'
 
 function run(stage, command, args, cwd) {
   const result = spawnSync(command, args, {

--- a/src/package-version.generated.ts
+++ b/src/package-version.generated.ts
@@ -1,3 +1,3 @@
 /** Generated from package.json by scripts/sync-package-versions.mjs. */
 export const DSH_AWIKI_PACKAGE_VERSION = "0.3.9" as const
-export const DSH_AWIKI_MODEL_PROXY_PACKAGE_VERSION = "0.1.4" as const
+export const DSH_AWIKI_MODEL_PROXY_PACKAGE_VERSION = "0.1.5" as const

--- a/tests/e2e-harness.spec.ts
+++ b/tests/e2e-harness.spec.ts
@@ -106,7 +106,7 @@ describe('DSH Web E2E Harness contract', () => {
       localIdentityNode: '0.2.0',
       localIdentitySourceRef: '8dc65ccc388af0f0622263811776a6aadcd11d18',
       localImCoreNode: '0.2.3',
-      localImCoreSourceRef: 'c2a9a2b6ee80e0668592731b678701d16f6399f6',
+      localImCoreSourceRef: 'ba227c1fe616fe4b7d83a069453899c3e344e548',
     })
   })
 

--- a/tests/e2e/fixtures/harness-instance.ts
+++ b/tests/e2e/fixtures/harness-instance.ts
@@ -44,7 +44,7 @@ export const e2ePackageVersions = Object.freeze({
   localIdentityNode: '0.2.0',
   localIdentitySourceRef: '8dc65ccc388af0f0622263811776a6aadcd11d18',
   localImCoreNode: '0.2.3',
-  localImCoreSourceRef: 'c2a9a2b6ee80e0668592731b678701d16f6399f6',
+  localImCoreSourceRef: 'ba227c1fe616fe4b7d83a069453899c3e344e548',
 })
 
 export interface HarnessInstance {


### PR DESCRIPTION
上海发布使用 IM Core Node 0.2.3，但原生测试夹具仍绑定旧 Core；Model Proxy 插件当前版本已在 npm 存在。本次将夹具源锁更新为经过五平台构建与 packed-install 的精确提交，并分配 Model Proxy 插件 0.1.5，同步生成版本元数据。

验证：主插件 54 files / 510 tests passed；Model Proxy 插件 9 files / 103 tests passed；构建、类型和生成检查通过；真实 Harness 无写 Web smoke 1 passed，run `20260907T062021Z-6e3b7394`。本轮未执行真实短信、充值、模型消费人工验收。
