### PR TITLE
test(release): verify stable Shanghai plugin dependencies

### DIFF
--- a/tests/e2e-harness.spec.ts
+++ b/tests/e2e-harness.spec.ts
@@ -99,10 +99,10 @@ describe('DSH Web E2E Harness contract', () => {
   it('pins the coordinated registry candidates used by the real profile', () => {
     expect(e2ePackageVersions).toEqual({
       localPlugin: '0.3.9',
-      localModelProxy: '0.1.4',
-      identityPlugin: '0.1.0-dsh-test.20260831.1',
-      identityNode: '0.2.0-dsh-test.20260831.1',
-      imCoreNode: '0.2.1-dsh-test.20260831.1',
+      localModelProxy: '0.1.5',
+      identityPlugin: '0.1.0',
+      identityNode: '0.2.0',
+      imCoreNode: '0.2.3',
       localIdentityNode: '0.2.0',
       localIdentitySourceRef: '8dc65ccc388af0f0622263811776a6aadcd11d18',
       localImCoreNode: '0.2.3',

--- a/tests/e2e/fixtures/harness-instance.ts
+++ b/tests/e2e/fixtures/harness-instance.ts
@@ -37,10 +37,10 @@ const inheritedEnvironmentKeys = [
 
 export const e2ePackageVersions = Object.freeze({
   localPlugin: '0.3.9',
-  localModelProxy: '0.1.4',
-  identityPlugin: '0.1.0-dsh-test.20260831.1',
-  identityNode: '0.2.0-dsh-test.20260831.1',
-  imCoreNode: '0.2.1-dsh-test.20260831.1',
+  localModelProxy: '0.1.5',
+  identityPlugin: '0.1.0',
+  identityNode: '0.2.0',
+  imCoreNode: '0.2.3',
   localIdentityNode: '0.2.0',
   localIdentitySourceRef: '8dc65ccc388af0f0622263811776a6aadcd11d18',
   localImCoreNode: '0.2.3',


### PR DESCRIPTION
Align no-write DSH Web smoke installation with the stable Shanghai release: ANP Identity 0.2.0, Identity plugin 0.1.0, IM Core 0.2.3, and model plugin 0.1.5. This checks the registry dependencies Desktop will install. Validation: E2E harness contract tests 9 passed; full candidate smoke follows after stable native packages are published.