### PR TITLE
fix(release): align DSH native header with daemon 0.1.93

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -55,6 +55,13 @@
 | `AWIKI_RECHARGE_ENABLED` | 源码常量 | 客户端充值 UI | **`true`** |
 | `NODE_ENV` | tsdown `define` | 打包时写入 | `production` |
 
+## 原生请求版本标识
+
+DSH `0.3.9` 使用 IM Core Node `0.2.3`，其原生源码与本次 Daemon `0.1.93` 同为
+`ba227c1fe616fe4b7d83a069453899c3e344e548`。Provider 沿用现有 Core 支持的
+`awiki-daemon/0815/0.1.93` 兼容版本头，匹配上海此次最低版本策略；这不新增产品枚举或协议能力。
+DSH 插件自身的更新检查仍使用插件包版本。
+
 ## 测试
 
 产品 loader 里测试专用旋钮就是 `allowInsecureLoopbackForTesting`（默认 `false`）。

--- a/lib/provider.js
+++ b/lib/provider.js
@@ -44,7 +44,7 @@ async function apply(ctx) {
 					clientVersionInfo: {
 						product: "awiki-daemon",
 						release: "0815",
-						version: "0.1.91"
+						version: "0.1.93"
 					},
 					multiDeviceHandleRecoveryEnabled: true,
 					multiDeviceDeviceRevokeEnabled: true,

--- a/lib/types/provider.js
+++ b/lib/types/provider.js
@@ -43,7 +43,7 @@ export async function apply(ctx) {
                     clientVersionInfo: {
                         product: 'awiki-daemon',
                         release: '0815',
-                        version: '0.1.91',
+                        version: '0.1.93',
                     },
                     multiDeviceHandleRecoveryEnabled: true,
                     multiDeviceDeviceRevokeEnabled: true,

--- a/src/provider.ts
+++ b/src/provider.ts
@@ -46,7 +46,7 @@ type OpenOptionsWithIdentityProvider = Parameters<typeof openImCoreNodeClient>[0
   readonly clientVersionInfo: {
     readonly product: 'awiki-daemon'
     readonly release: '0815'
-    readonly version: '0.1.91'
+    readonly version: '0.1.93'
   }
 }
 
@@ -74,7 +74,7 @@ export async function apply(ctx: Context): Promise<void> {
             clientVersionInfo: {
               product: 'awiki-daemon',
               release: '0815',
-              version: '0.1.91',
+              version: '0.1.93',
             },
             multiDeviceHandleRecoveryEnabled: true,
             multiDeviceDeviceRevokeEnabled: true,

--- a/tests/provider.spec.ts
+++ b/tests/provider.spec.ts
@@ -75,7 +75,7 @@ describe('AWiki production provider', () => {
       clientVersionInfo: {
         product: 'awiki-daemon',
         release: '0815',
-        version: '0.1.91',
+        version: '0.1.93',
       },
       multiDeviceDeviceRevokeEnabled: true,
     })


### PR DESCRIPTION
DSH 0.3.9 embeds IM Core Node 0.2.3 built from the same ba227c1 source as Daemon 0.1.93. Replace the stale 0.1.91 native compatibility header with awiki-daemon/0815/0.1.93 so the Shanghai minimum version policy accepts this actual release. Preserve the existing product enum and DSH own package update policy. Validation: the provider regression failed on the old header then all 3 focused tests passed; build and generated checks passed. Generated provider bundles are included.